### PR TITLE
fix Gemfile so that it doesnt make http requests to determine the github-pages version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,10 +1,6 @@
 source 'https://rubygems.org'
 
-require 'json'
-require 'open-uri'
-versions = JSON.parse(open('https://pages.github.com/versions.json').read)
-
-gem 'github-pages', versions['github-pages']
+gem 'github-pages'
 gem 'html-proofer'
 gem 'rake'
 gem 'google-api-client', '0.8'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -180,10 +180,9 @@ PLATFORMS
 
 DEPENDENCIES
   chronic
-  github-pages (= 42)
+  github-pages
   google-api-client (= 0.8)
   html-proofer
-  json
   rake
 
 BUNDLED WITH


### PR DESCRIPTION

Not really sure why this was added like this, but their current documentation says to just list 'github-pages' in the Gemfile:
https://github.com/github/pages-gem