### PR TITLE
Downloads

### DIFF
--- a/pages/downloads/current.md
+++ b/pages/downloads/current.md
@@ -32,8 +32,9 @@ Use the download links below to download the latest version of the SDK:
 {% endif %}
 
 {% endfor %}
+{% assign bcnum = beta_count | round %}
 
-{% if beta_count != 0 %}
+{% if bcnum > 0 %}
 
 #### In Development
 

--- a/pages/downloads/current.md
+++ b/pages/downloads/current.md
@@ -20,12 +20,26 @@ Use the download links below to download the latest version of the SDK:
 #### Stable Release
 {% include custom/download_table.html build_status="stable" %}
 
-<!--
+
+{% assign beta_count = 0 %}
+
+{% for platform in site.data.downloads.platforms %}
+{% assign beta_array = platform.versions | where: "status","beta" %}
+{% assign beta_array_size = beta_array | size %}
+
+{% if beta_array_size > 0 %}
+{% capture beta_count %}{{ beta_count | plus:1 }}{% endcapture %}
+{% endif %}
+
+{% endfor %}
+
+{% if beta_count != 0 %}
+
 #### In Development
 
 Download release candidates of the SDK. The release candidates are in the final stage of testing. Feel free to [report bugs](mailto:sdk@affectiva.com?subject=Bug Report).  
 
 {% include custom/download_table.html build_status="beta" %}
--->
+{% endif %}
 
 Download an [older release](/downloads/previous).


### PR DESCRIPTION
added liquid code to count beta releases on downloads page to determine whether or not to display beta release blurb and table