### PR TITLE
updates for Android 3.1.2 and Unity 2.2.1 release

### DIFF
--- a/_data/downloads.yml
+++ b/_data/downloads.yml
@@ -15,17 +15,23 @@ platforms:
     salesForcePoIPlatform: Android
     versions:
       - status: stable
+        release_notes: affdex-sdk-version-312
+        architecture: "ARM7"
+        version: "3.1.2"
+        install: /v3_1_2/android/
+        size: 7.0 MB
+      - status: legacy
         release_notes: affdex-sdk-version-311
         architecture: "ARM7"
         version: "3.1.1"
         install: /v3_1_1/android/
-        size: 6.5 MB
+        size: 7.0 MB
       - status: legacy
         release_notes: affdex-sdk-version-31
         architecture: "ARM7"
         version: "3.1"
-        install: /v3_1_1/android/
-        size: 6.5 MB
+        install: /v3_1/android/
+        size: 7.0 MB
       - status: legacy
         release_notes: affdex-sdk-version-301
         doc: /v3/android/
@@ -184,6 +190,13 @@ platforms:
     salesForcePoIPlatform: Unity
     versions:
     - status: stable
+      doc: /v2_2/unity/
+      architecture: OSX i386/x86_64, Windows x86/x86_64, Android ARM7/x86
+      version: "2.2.1"
+      package: https://download.affectiva.com/unity/AffdexDelivery_2_2_1.unitypackage
+      size: 37 MB
+
+    - status: legacy
       doc: /v2_2/unity/
       architecture: OSX i386/x86_64, Windows x86/x86_64, Android ARM7/x86
       version: "2.2"

--- a/_data/sidebar.yml
+++ b/_data/sidebar.yml
@@ -78,7 +78,7 @@ entries:
 
       items:
         - title: Android (Java)
-          url: /v3_1_1/android/
+          url: /v3_1_2/android/
           audience: developer, designer
           platform: all
           product: all

--- a/pages/overview/whats_new.md
+++ b/pages/overview/whats_new.md
@@ -11,6 +11,13 @@ metadata: true
 
 This page contains the release notes for the different versions of the Affdex SDK(s).
 
+### Unity Plugin 2.2.1
+
+*Sep 2016*
+
+* Android
+  * Updated the libpng version used in the native library to address a security vulnerability
+
 ### Unity Plugin 2.2
 
 *Aug 2016*
@@ -20,6 +27,15 @@ This page contains the release notes for the different versions of the Affdex SD
 * Frame constructor can now accept a rotation angle of 0, 90, 180, and 270.
 * Detector.Initialize is now private because it is called automatically by Detector.Start
 * Detector.Stop has been deprecated in favor of Detector.StopDetector
+
+***
+
+### Affdex SDK version 3.1.2
+
+*Sep 2016*
+
+* Android
+  * Updated libpng version used in native library to address security vulnerability
 
 ***
 

--- a/pages/platforms/v3_1_2/android/ando.md
+++ b/pages/platforms/v3_1_2/android/ando.md
@@ -1,6 +1,7 @@
 ---
 title: Affdex SDK for Android
-permalink: /v3_1_1/android/
+permalink: /v3_1_2/android/
+redirect_from: "/android/"
 tags: [android, sdk]
 audience: writer, designer
 keywords:
@@ -11,7 +12,7 @@ metadata: false
 
 {% include linkrefs.html %}
 
-SDK Developer Guide Release 3.1.1
+SDK Developer Guide Release 3.1.2
 
 ## Using the SDK
 
@@ -34,7 +35,7 @@ For an example please see the [AffdexMe sample app's top-level build.gradle file
 ```groovy
 dependencies {
     ...
-    compile 'com.affectiva.android:affdexsdk:3.1.1'
+    compile 'com.affectiva.android:affdexsdk:3.1.2'
     ...
 }
 ```
@@ -90,7 +91,7 @@ You can then add your own "allowBackup" and "label" attributes:
 ##### 4. Capture and analyze faces
 
 Facial images can be captured from different sources. For each of the different sources, the SDK defines a detector class that can handle processing images acquired from that source:
-
+<!--- note: same as 3.1.1, so reuse that content -->
 * [How to analyze a camera feed]({{ site.baseurl }}/v3_1_1/android/analyze-camera/)
 * [How to analyze a recorded video file]({{ site.baseurl }}/v3_1_1/android/analyze-video/)
 * [How to analyze a video frame stream]({{ site.baseurl }}/v3_1_1/android/analyze-frames/)
@@ -100,6 +101,7 @@ Facial images can be captured from different sources. For each of the different 
 Sample applications for processing videos, and connecting to the camera are available for cloning on our [GitHub repository.](http://github.com/Affectiva/android-sdk-samples)
 
 ## Class documentation
+<!--- note: same as 3.1.1, so reuse that javadoc -->
 * class docs: [[HTML]({{ site.baseurl }}/pages/platforms/v3_1_1/android/javadoc/index.html)]
 
 ## Requirements & Dependencies


### PR DESCRIPTION
Android 3.1.2
- has new platform page showing the 3.1.2 gradle dependency
- the "how to analyze a {...}" links on that page point to the 3.1.1
 files, since they haven't changed.  Javadoc, too.
- new entry on the What's New page under heading "Affdex SDK version 3.1.2"
- new entry on the Previous Releases page for 3.1.1

Unity 2.2.1
- existing "2.2.x" platform page updated with a new top row in the
  download table.
- new entry on the What's New page under heading "Unity Plugin 2.2.1"
- new entry on the Previous Releases page for 2.2