### PR TITLE
Fixed markdown typo on android page

### DIFF
--- a/pages/platforms/v3_1/android/ando.md
+++ b/pages/platforms/v3_1/android/ando.md
@@ -89,7 +89,7 @@ You can then add your own "allowBackup" and "label" attributes:
 
 ##### 4. Capture and analyze faces
 
-Facial images can be captured from different sources. For each of the different sources, the SDK defines a detector class that can handle processing images acquired from that source:  
+Facial images can be captured from different sources. For each of the different sources, the SDK defines a detector class that can handle processing images acquired from that source:
 
 * [How to analyze a camera feed]({{ site.baseurl }}/v3/android/analyze-camera/)
 * [How to analyze a recorded video file]({{ site.baseurl }}/v3/android/analyze-video/)

--- a/pages/platforms/v3_1/android/ando.md
+++ b/pages/platforms/v3_1/android/ando.md
@@ -89,7 +89,7 @@ You can then add your own "allowBackup" and "label" attributes:
 
 ##### 4. Capture and analyze faces
 
-Facial images can be captured from different sources. For each of the different sources, the SDK defines a detector class that can handle processing images acquired from that source:
+Facial images can be captured from different sources. For each of the different sources, the SDK defines a detector class that can handle processing images acquired from that source:  
 
 * [How to analyze a camera feed]({{ site.baseurl }}/v3/android/analyze-camera/)
 * [How to analyze a recorded video file]({{ site.baseurl }}/v3/android/analyze-video/)

--- a/pages/platforms/v3_1_2/android/ando.md
+++ b/pages/platforms/v3_1_2/android/ando.md
@@ -92,6 +92,7 @@ You can then add your own "allowBackup" and "label" attributes:
 
 Facial images can be captured from different sources. For each of the different sources, the SDK defines a detector class that can handle processing images acquired from that source:
 <!--- note: same as 3.1.1, so reuse that content -->
+
 * [How to analyze a camera feed]({{ site.baseurl }}/v3_1_1/android/analyze-camera/)
 * [How to analyze a recorded video file]({{ site.baseurl }}/v3_1_1/android/analyze-video/)
 * [How to analyze a video frame stream]({{ site.baseurl }}/v3_1_1/android/analyze-frames/)


### PR DESCRIPTION
Current page has issue in unordered list because of lack of two trailing spaces on line above list.